### PR TITLE
Fix for patch_inplace when the resulting file is smaller than before

### DIFF
--- a/bsdiff4/format.py
+++ b/bsdiff4/format.py
@@ -107,6 +107,7 @@ def file_patch_inplace(path, patch_path):
     data = f.read()
     f.seek(0)
     f.write(core.patch(data, *read_patch(fi)))
+    f.truncate()
     f.close()
     fi.close()
 


### PR DESCRIPTION
Depending on the patch data, the resulting file could be smaller than before.

Since it is opened in append mode, seeking to 0 and writing the patch data would leave the remainder of the file untouched if the patched data was shorter than the original data.

Added the necessary f.truncate() statement. Cheers!
