### PR TITLE
Use setuptools to enable binary wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import re
 from os.path import join
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 
 kwds = {}


### PR DESCRIPTION
Wheels build successfully on windows and linux with ```python setup.py bdist_wheel```