### PR TITLE
handle signals in the diff function so this code can be interrupted if it's stuck

### DIFF
--- a/bsdiff4/core.c
+++ b/bsdiff4/core.c
@@ -256,6 +256,10 @@ diff(PyObject *self, PyObject *args)
     lastoffset = 0;
     pos = 0;
     while (scan < newDataLength) {
+        if (PyErr_CheckSignals() != 0) {
+            PyErr_SetNone(PyExc_KeyboardInterrupt);
+            return NULL;
+        }
         oldscore = 0;
 
         Py_BEGIN_ALLOW_THREADS  /* release GIL */
@@ -361,6 +365,7 @@ diff(PyObject *self, PyObject *args)
             lastoffset = pos - scan;
         }
     }
+
 
     PyMem_Free(I);
     results = PyTuple_New(3);


### PR DESCRIPTION
Sometimes the bsdiff function can try to diff some pathological case which takes a long time (e.g. issue #9) and we'd like to CTRL-C from the Python shell; previously the code didn't check any python signals so the Ctrl-C wouldn't be handled until the diff function call completed.

I added this code based on this StackOverflow comment: https://stackoverflow.com/questions/14707049/allowing-ctrl-c-to-interrupt-a-python-c-extension